### PR TITLE
Update winnings calc in dashboard

### DIFF
--- a/src/hooks/useAppLogic.js
+++ b/src/hooks/useAppLogic.js
@@ -95,7 +95,13 @@ export function useWinningsChartData(myBets, timeFilter) {
     .sort((a, b) => a.createdAt?.toDate() - b.createdAt?.toDate())
     .reduce((acc, bet) => {
       const date = bet.createdAt?.toDate().toLocaleDateString("en-US", { month: "2-digit", day: "2-digit" });
-      const change = bet.status === "win" ? bet.wagerAmount : -bet.wagerAmount;
+      const parlayOdds = bet.bets?.reduce((oAcc, b) => {
+        const dec = b.odds > 0 ? b.odds / 100 + 1 : 100 / Math.abs(b.odds) + 1;
+        return oAcc * dec;
+      }, 1) ?? 1;
+      const change = bet.status === "win"
+        ? bet.wagerAmount * parlayOdds
+        : -bet.wagerAmount;
       const last = acc.length > 0 ? acc[acc.length - 1].total : 0;
       acc.push({ name: date, total: last + change });
       return acc;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -33,7 +33,13 @@ export default function Dashboard({ user }) {
       .sort((a, b) => a.createdAt?.toDate() - b.createdAt?.toDate())
       .reduce((acc, bet) => {
         const date = bet.createdAt?.toDate().toLocaleDateString("en-US", { month: "2-digit", day: "2-digit" });
-        const change = bet.status === "win" ? bet.wagerAmount : -bet.wagerAmount;
+        const parlayOdds = bet.bets?.reduce((oAcc, b) => {
+          const dec = b.odds > 0 ? b.odds / 100 + 1 : 100 / Math.abs(b.odds) + 1;
+          return oAcc * dec;
+        }, 1) ?? 1;
+        const change = bet.status === "win"
+          ? bet.wagerAmount * parlayOdds
+          : -bet.wagerAmount;
         const last = acc.length > 0 ? acc[acc.length - 1].total : 0;
         acc.push({ name: date, total: last + change });
         return acc;


### PR DESCRIPTION
## Summary
- calculate parlay odds when computing dashboard winnings
- update winnings chart data helper to use odds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843cf754e348333aa3e210eb5e8d1f6